### PR TITLE
refactor: centralize user role lookup

### DIFF
--- a/frontend/context/AuthContext.js
+++ b/frontend/context/AuthContext.js
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { auth, db } from '../firebase/config'
+import { auth } from '../firebase/config'
 import { onAuthStateChanged } from 'firebase/auth'
-import { doc, getDoc } from 'firebase/firestore'
+import { getUserRole } from '../utils/getUserRole'
 
 const AuthContext = createContext({
   user: null,
@@ -22,24 +22,8 @@ export function AuthProvider({ children }) {
     const unsubscribe = onAuthStateChanged(auth, async user => {
       if (user) {
         setUser(user)
-        try {
-          let data = null
-          const refUsers = doc(db, 'users', user.uid)
-          const snapUsers = await getDoc(refUsers)
-          if (snapUsers.exists()) {
-            data = snapUsers.data()
-          } else {
-            const refUser = doc(db, 'user', user.uid)
-            const snapUser = await getDoc(refUser)
-            if (snapUser.exists()) {
-              data = snapUser.data()
-            }
-          }
-          setRole(data?.rol ?? data?.role ?? null)
-        } catch (error) {
-          console.error('Error obteniendo rol de usuario:', error)
-          setRole(null)
-        }
+        const role = await getUserRole(user.uid)
+        setRole(role)
       } else {
         setUser(null)
         setRole(null)

--- a/frontend/pages/auth/login.jsx
+++ b/frontend/pages/auth/login.jsx
@@ -3,11 +3,11 @@ import Image from 'next/image'
 import { useState } from 'react'
 import Link from 'next/link'
 import { signInWithPopup, signInWithEmailAndPassword } from 'firebase/auth'
-import { auth, provider, db } from '../../firebase/config'
+import { auth, provider } from '../../firebase/config'
 import { useRouter } from 'next/router'
 import { FcGoogle } from 'react-icons/fc'
-import { doc, getDoc } from 'firebase/firestore'
 import { redirectByRole } from '../../utils/redirectByRole'
+import { getUserRole } from '../../utils/getUserRole'
 
 export default function Login() {
   const router = useRouter()
@@ -19,18 +19,7 @@ export default function Login() {
       const result = await signInWithPopup(auth, provider)
       const user = result.user
       console.log("Usuario autenticado:", user)
-      let role = null
-      const snap = await getDoc(doc(db, 'users', user.uid))
-      if (snap.exists()) {
-        const data = snap.data()
-        role = data.rol ?? data.role ?? null
-      } else {
-        const snap2 = await getDoc(doc(db, 'user', user.uid))
-        if (snap2.exists()) {
-          const data2 = snap2.data()
-          role = data2.rol ?? data2.role ?? null
-        }
-      }
+      const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
       console.error("Error al iniciar sesión con Google:", error)
@@ -42,18 +31,7 @@ export default function Login() {
       const result = await signInWithEmailAndPassword(auth, email, password)
       const user = result.user
       console.log('Usuario autenticado:', user)
-      let role = null
-      const snap = await getDoc(doc(db, 'users', user.uid))
-      if (snap.exists()) {
-        const data = snap.data()
-        role = data.rol ?? data.role ?? null
-      } else {
-        const snap2 = await getDoc(doc(db, 'user', user.uid))
-        if (snap2.exists()) {
-          const data2 = snap2.data()
-          role = data2.rol ?? data2.role ?? null
-        }
-      }
+      const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
       console.error('Error al iniciar sesión con correo:', error)

--- a/frontend/utils/getUserRole.js
+++ b/frontend/utils/getUserRole.js
@@ -1,0 +1,26 @@
+import { db } from '../firebase/config'
+import { doc, getDoc } from 'firebase/firestore'
+
+export async function getUserRole(userId) {
+  try {
+    if (!userId) return null
+
+    let data = null
+    const refUsers = doc(db, 'users', userId)
+    const snapUsers = await getDoc(refUsers)
+    if (snapUsers.exists()) {
+      data = snapUsers.data()
+    } else {
+      const refUser = doc(db, 'user', userId)
+      const snapUser = await getDoc(refUser)
+      if (snapUser.exists()) {
+        data = snapUser.data()
+      }
+    }
+
+    return data?.rol ?? data?.role ?? null
+  } catch (error) {
+    console.error('Error obteniendo rol de usuario:', error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- add `getUserRole` utility to fetch role from Firestore with error handling
- use `getUserRole` in auth context to set role consistently
- simplify login page role lookup using new utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd frontend && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a45bbc14832c8aa717a3d12e9808