### PR TITLE
Validate advisor API message and add tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,10 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test"
   },
+  "type": "module",
   "dependencies": {
     "firebase": "^10.0.0",
     "next": "13.4.12",

--- a/frontend/pages/api/__tests__/advisor.test.js
+++ b/frontend/pages/api/__tests__/advisor.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import handler, { MAX_MESSAGE_LENGTH } from '../advisor.js'
+
+function createRes() {
+  return {
+    statusCode: 0,
+    body: null,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = data
+      return this
+    }
+  }
+}
+
+test('responds 400 when message is empty', async () => {
+  const req = { method: 'POST', body: { message: '' } }
+  const res = createRes()
+  await handler(req, res)
+  assert.equal(res.statusCode, 400)
+})
+
+test('responds 400 when message exceeds max length', async () => {
+  const req = { method: 'POST', body: { message: 'a'.repeat(MAX_MESSAGE_LENGTH + 1) } }
+  const res = createRes()
+  await handler(req, res)
+  assert.equal(res.statusCode, 400)
+})

--- a/frontend/pages/api/advisor.js
+++ b/frontend/pages/api/advisor.js
@@ -1,15 +1,23 @@
-import { Configuration, OpenAIApi } from 'openai'
+export const MAX_MESSAGE_LENGTH = 500
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
+
   const { message } = req.body
+  if (typeof message !== 'string' || message.trim() === '' || message.length > MAX_MESSAGE_LENGTH) {
+    return res.status(400).json({ error: 'Invalid message' })
+  }
+
   if (!process.env.OPENAI_API_KEY) {
     return res.status(500).json({ error: 'OpenAI API key not configured' })
   }
+
+  const { Configuration, OpenAIApi } = await import('openai')
   const config = new Configuration({ apiKey: process.env.OPENAI_API_KEY })
   const openai = new OpenAIApi(config)
+
   try {
     const completion = await openai.createChatCompletion({
       model: 'gpt-3.5-turbo',
@@ -18,6 +26,7 @@ export default async function handler(req, res) {
         { role: 'user', content: message }
       ]
     })
+
     const reply = completion.data.choices[0].message.content
     res.status(200).json({ response: reply })
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure `advisor` API only accepts non-empty string messages up to 500 chars
- add unit tests for empty and overlong messages
- configure frontend package for ESM and provide `npm test`

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a45eaf94832cb3ab7bd777b19689