### PR TITLE
refactor: centralize user role retrieval

### DIFF
--- a/frontend/pages/auth/login.jsx
+++ b/frontend/pages/auth/login.jsx
@@ -19,6 +19,7 @@ export default function Login() {
       const result = await signInWithPopup(auth, provider)
       const user = result.user
       console.log("Usuario autenticado:", user)
+      // Obtiene el rol del usuario y redirige según corresponda
       const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
@@ -31,6 +32,7 @@ export default function Login() {
       const result = await signInWithEmailAndPassword(auth, email, password)
       const user = result.user
       console.log('Usuario autenticado:', user)
+      // Obtiene el rol del usuario y redirige según corresponda
       const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {

--- a/frontend/utils/getUserRole.js
+++ b/frontend/utils/getUserRole.js
@@ -1,24 +1,27 @@
-import { db } from '../firebase/config'
 import { doc, getDoc } from 'firebase/firestore'
+import { db } from '../firebase/config'
 
+/**
+ * Busca el rol del usuario en las colecciones "users" y "user".
+ * @param {string} userId - UID del usuario autenticado.
+ * @returns {Promise<string|null>} Rol encontrado o `null` si no existe.
+ */
 export async function getUserRole(userId) {
+  if (!userId) return null
   try {
-    if (!userId) return null
-
-    let data = null
-    const refUsers = doc(db, 'users', userId)
-    const snapUsers = await getDoc(refUsers)
-    if (snapUsers.exists()) {
-      data = snapUsers.data()
-    } else {
-      const refUser = doc(db, 'user', userId)
-      const snapUser = await getDoc(refUser)
-      if (snapUser.exists()) {
-        data = snapUser.data()
-      }
+    const usersSnap = await getDoc(doc(db, 'users', userId))
+    if (usersSnap.exists()) {
+      const data = usersSnap.data()
+      return data.role ?? data.rol ?? null
     }
 
-    return data?.rol ?? data?.role ?? null
+    const userSnap = await getDoc(doc(db, 'user', userId))
+    if (userSnap.exists()) {
+      const data = userSnap.data()
+      return data.role ?? data.rol ?? null
+    }
+
+    return null
   } catch (error) {
     console.error('Error obteniendo rol de usuario:', error)
     return null


### PR DESCRIPTION
## Summary
- refactor user role helper to search both 'users' and 'user' collections
- reuse getUserRole in login flow and keep redirectByRole invocation

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a7a8dc7b3c832cb81bb46a180dc8e1