### PR TITLE
feat: add toast notifications and dev error helper

### DIFF
--- a/frontend/components/Notification.jsx
+++ b/frontend/components/Notification.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState, useCallback } from 'react'
+
+const NotificationContext = createContext(() => {})
+
+export function NotificationProvider({ children }) {
+  const [notification, setNotification] = useState(null)
+
+  const showNotification = useCallback((message, type = 'info') => {
+    setNotification({ message, type })
+    setTimeout(() => setNotification(null), 3000)
+  }, [])
+
+  return (
+    <NotificationContext.Provider value={showNotification}>
+      {children}
+      {notification && (
+        <div
+          className={`fixed top-4 right-4 px-4 py-2 rounded shadow-md text-white ${
+            notification.type === 'error' ? 'bg-red-500' : 'bg-green-500'
+          }`}
+        >
+          {notification.message}
+        </div>
+      )}
+    </NotificationContext.Provider>
+  )
+}
+
+export function useNotification() {
+  return useContext(NotificationContext)
+}
+

--- a/frontend/components/ProductForm.jsx
+++ b/frontend/components/ProductForm.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react'
 import { db, storage } from '../firebase/config'
 import { collection, addDoc, updateDoc, doc } from 'firebase/firestore'
 import { ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage'
+import { useNotification } from './Notification'
+import { devError } from '../utils/devError'
 
 export default function ProductForm({ onClose, productToEdit }) {
   const [codigo, setCodigo] = useState('')
@@ -15,6 +17,7 @@ export default function ProductForm({ onClose, productToEdit }) {
   const [proveedor, setProveedor] = useState('')
   const [imagenes, setImagenes] = useState([])
   const [selectedFiles, setSelectedFiles] = useState([])
+  const notify = useNotification()
 
   useEffect(() => {
     setSelectedFiles([])
@@ -80,9 +83,10 @@ export default function ProductForm({ onClose, productToEdit }) {
           try {
             return await uploadFileWithRetry(file)
           } catch (err) {
-            console.error('Error subiendo imagen tras varios intentos:', err)
-            alert(
-              'Error subiendo la imagen después de varios intentos: ' + err.message
+            devError('Error subiendo imagen tras varios intentos:', err)
+            notify(
+              'Error subiendo la imagen después de varios intentos: ' + err.message,
+              'error'
             )
             return null
           }
@@ -98,11 +102,11 @@ export default function ProductForm({ onClose, productToEdit }) {
       } else {
         await addDoc(collection(db, 'products'), data)
       }
-      alert('Producto guardado correctamente')
+      notify('Producto guardado correctamente', 'success')
       onClose()
     } catch (error) {
-      console.error('Error guardando producto:', error)
-      alert('Error al guardar el producto: ' + error.message)
+      devError('Error guardando producto:', error)
+      notify('Error al guardar el producto: ' + error.message, 'error')
     }
   }
 

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -2,13 +2,17 @@
 import '../styles/globals.css'
 import { AuthProvider } from '../context/AuthContext'
 import { CartProvider } from '../context/CartContext'
+import { NotificationProvider } from '../components/Notification'
 
 export default function App({ Component, pageProps }) {
   return (
     <AuthProvider>
       <CartProvider>
-        <Component {...pageProps} />
+        <NotificationProvider>
+          <Component {...pageProps} />
+        </NotificationProvider>
       </CartProvider>
     </AuthProvider>
   )
 }
+

--- a/frontend/pages/auth/login.jsx
+++ b/frontend/pages/auth/login.jsx
@@ -8,11 +8,14 @@ import { useRouter } from 'next/router'
 import { FcGoogle } from 'react-icons/fc'
 import { redirectByRole } from '../../utils/redirectByRole'
 import { getUserRole } from '../../utils/getUserRole'
+import { useNotification } from '../../components/Notification'
+import { devError } from '../../utils/devError'
 
 export default function Login() {
   const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const notify = useNotification()
 
   const handleGoogleLogin = async () => {
     try {
@@ -22,7 +25,8 @@ export default function Login() {
       const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
-      console.error("Error al iniciar sesión con Google:", error)
+      devError('Error al iniciar sesión con Google:', error)
+      notify('Error al iniciar sesión con Google: ' + error.message, 'error')
     }
   }
   const handleEmailLogin = async (e) => {
@@ -34,8 +38,8 @@ export default function Login() {
       const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
-      console.error('Error al iniciar sesión con correo:', error)
-      alert('Error al iniciar sesión: ' + error.message)
+      devError('Error al iniciar sesión con correo:', error)
+      notify('Error al iniciar sesión: ' + error.message, 'error')
     }
   }
 

--- a/frontend/utils/devError.js
+++ b/frontend/utils/devError.js
@@ -1,0 +1,6 @@
+export function devError(...args) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(...args)
+  }
+}
+


### PR DESCRIPTION
## Summary
- add global notification provider for toast messages
- replace alert and console.error in product form and login page
- centralize error logging with devError helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a8e2d66c832cbda42d19abc2e3af