### PR TITLE
Add Jest testing setup with sample devLogger test

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
+};

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "type": "module",
   "dependencies": {
@@ -20,7 +20,11 @@
     "pdfmake": "^0.2.7"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
     "autoprefixer": "^10.4.21",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17"
   }

--- a/frontend/utils/devLogger.js
+++ b/frontend/utils/devLogger.js
@@ -1,0 +1,5 @@
+export const devLogger = (...args) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(...args);
+  }
+};

--- a/frontend/utils/devLogger.test.js
+++ b/frontend/utils/devLogger.test.js
@@ -1,0 +1,24 @@
+import { devLogger } from './devLogger.js';
+
+describe('devLogger', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('logs messages in development mode', () => {
+    process.env.NODE_ENV = 'development';
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    devLogger('hello');
+    expect(logSpy).toHaveBeenCalledWith('hello');
+  });
+
+  it('does not log messages in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    devLogger('hello');
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest and React Testing Library for the frontend project
- add devLogger utility with accompanying Jest test
- include Jest configuration and setup files

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a7a8ed5574832cbae42d3026878d96