### PR TITLE
feat: centralize development error logging

### DIFF
--- a/frontend/components/CartModule.jsx
+++ b/frontend/components/CartModule.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import { db } from '../firebase/config'
 import { doc, getDoc } from 'firebase/firestore'
 import { useCart } from '../context/CartContext'
+import { devError } from '../utils/devLog'
 
 export default function CartModule() {
   const { cartItems, updateQuantity, removeFromCart, totalPrice } = useCart()
@@ -20,7 +21,7 @@ export default function CartModule() {
           setErrorRate(new Error('No se encontró la tasa de cambio'))
         }
       } catch (err) {
-        console.error('Error cargando tasa de cambio:', err)
+        devError('Error cargando tasa de cambio:', err)
         setErrorRate(err)
       } finally {
         setLoadingRate(false)

--- a/frontend/components/CatalogModule.jsx
+++ b/frontend/components/CatalogModule.jsx
@@ -3,6 +3,7 @@ import { db } from '../firebase/config'
 import { collection, getDocs } from 'firebase/firestore'
 import ProductCard from './ProductCard'
 import { categories as navCategories, navStructure } from './Navbar'
+import { devError } from '../utils/devLog'
 
 export default function CatalogModule({ category: propCategory = '', onCategoryChange }) {
 
@@ -25,7 +26,7 @@ export default function CatalogModule({ category: propCategory = '', onCategoryC
         const items = snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
         setProducts(items)
       } catch (err) {
-        console.error('Error cargando productos:', err)
+        devError('Error cargando productos:', err)
         setError(err)
       } finally {
         setLoading(false)

--- a/frontend/components/DashboardCards.jsx
+++ b/frontend/components/DashboardCards.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { FaShoppingCart, FaBoxOpen, FaUsers, FaProjectDiagram } from 'react-icons/fa'
 import { db } from '../firebase/config'
 import { collection, getDocs } from 'firebase/firestore'
+import { devError } from '../utils/devLog'
 
 export default function DashboardCards() {
   const [data, setData] = useState({ ventas: 0, productos: 0, usuarios: 0, proyectos: 0 })
@@ -22,7 +23,7 @@ export default function DashboardCards() {
           proyectos: proyectosSnap.size,
         })
       } catch (error) {
-        console.error('Error fetching dashboard counts:', error)
+        devError('Error fetching dashboard counts:', error)
       }
     }
     fetchCounts()

--- a/frontend/components/FeaturedProducts.jsx
+++ b/frontend/components/FeaturedProducts.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { db } from '../firebase/config'
 import { collection, query, limit, getDocs } from 'firebase/firestore'
 import ProductCard from './ProductCard'
+import { devError } from '../utils/devLog'
 
 export default function FeaturedProducts() {
   const [products, setProducts] = useState([])
@@ -14,7 +15,7 @@ export default function FeaturedProducts() {
         const items = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
         setProducts(items)
       } catch (error) {
-        console.error('Error cargando productos destacados:', error)
+        devError('Error cargando productos destacados:', error)
       }
     }
     fetchFeatured()

--- a/frontend/components/InventoryTable.jsx
+++ b/frontend/components/InventoryTable.jsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import { useRouter } from 'next/router'
 import * as XLSX from 'xlsx'
 import { FaSearch, FaFileExcel, FaFilePdf } from 'react-icons/fa'
+import { devError } from '../utils/devLog'
 
 
 export default function InventoryTable() {
@@ -60,7 +61,7 @@ export default function InventoryTable() {
       setProducts(data)
       setFiltered(data)
     } catch (err) {
-      console.error('Error fetching products:', err)
+      devError('Error fetching products:', err)
     }
   }
 
@@ -114,7 +115,7 @@ export default function InventoryTable() {
       setProductSales(data.sales)
       setProductSalesTotals({ totalQuantity: data.totalQuantity, totalAmount: data.totalAmount })
     } catch (err) {
-      console.error('Error fetching product sales:', err)
+      devError('Error fetching product sales:', err)
     }
   }
 

--- a/frontend/components/OrdersTable.jsx
+++ b/frontend/components/OrdersTable.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { db } from '../firebase/config'
 import { collection, onSnapshot, updateDoc, doc, getDoc } from 'firebase/firestore'
+import { devError } from '../utils/devLog'
 
 const STATUSES = [
   'Pendiente',
@@ -45,7 +46,7 @@ export default function OrdersTable() {
       }
       await updateDoc(doc(db, 'orders', orderId), { status: newStatus })
     } catch (error) {
-      console.error('Error actualizando estado de orden:', error)
+      devError('Error actualizando estado de orden:', error)
       alert('Error actualizando estado: ' + error.message)
     }
   }

--- a/frontend/components/ProductCard.jsx
+++ b/frontend/components/ProductCard.jsx
@@ -5,6 +5,7 @@ import { FiHeart, FiShare2 } from 'react-icons/fi'
 import { FaWhatsapp } from 'react-icons/fa'
 import { db } from '../firebase/config'
 import { doc, getDoc } from 'firebase/firestore'
+import { devError } from '../utils/devLog'
 
 export default function ProductCard({ product }) {
   const { addToCart } = useCart()
@@ -49,7 +50,7 @@ export default function ProductCard({ product }) {
       localStorage.setItem('favorites', JSON.stringify(updated))
       setLiked(!liked)
     } catch (error) {
-      console.error('Error actualizando favoritos', error)
+      devError('Error actualizando favoritos', error)
     }
   }
 
@@ -65,7 +66,7 @@ export default function ProductCard({ product }) {
         alert('Enlace copiado al portapapeles')
       }
     } catch (error) {
-      console.error('Error compartiendo', error)
+      devError('Error compartiendo', error)
     }
   }
 

--- a/frontend/components/ProductForm.jsx
+++ b/frontend/components/ProductForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { db, storage } from '../firebase/config'
 import { collection, addDoc, updateDoc, doc } from 'firebase/firestore'
 import { ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage'
+import { devError } from '../utils/devLog'
 
 export default function ProductForm({ onClose, productToEdit }) {
   const [codigo, setCodigo] = useState('')
@@ -80,7 +81,7 @@ export default function ProductForm({ onClose, productToEdit }) {
           try {
             return await uploadFileWithRetry(file)
           } catch (err) {
-            console.error('Error subiendo imagen tras varios intentos:', err)
+            devError('Error subiendo imagen tras varios intentos:', err)
             alert(
               'Error subiendo la imagen después de varios intentos: ' + err.message
             )
@@ -101,7 +102,7 @@ export default function ProductForm({ onClose, productToEdit }) {
       alert('Producto guardado correctamente')
       onClose()
     } catch (error) {
-      console.error('Error guardando producto:', error)
+      devError('Error guardando producto:', error)
       alert('Error al guardar el producto: ' + error.message)
     }
   }

--- a/frontend/components/ProviderForm.jsx
+++ b/frontend/components/ProviderForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { db } from '../firebase/config'
 import { collection, addDoc, updateDoc, doc } from 'firebase/firestore'
+import { devError } from '../utils/devLog'
 
 export default function ProviderForm({ onClose, providerToEdit }) {
   const { role } = useAuth()
@@ -51,7 +52,7 @@ export default function ProviderForm({ onClose, providerToEdit }) {
       alert('Proveedor guardado correctamente')
       onClose()
     } catch (error) {
-      console.error('Error guardando proveedor:', error)
+      devError('Error guardando proveedor:', error)
       alert('Error al guardar el proveedor: ' + error.message)
     }
   }

--- a/frontend/components/ProvidersModule.jsx
+++ b/frontend/components/ProvidersModule.jsx
@@ -5,6 +5,7 @@ import { collection, getDocs } from 'firebase/firestore'
 import { FaFileExcel, FaFilePdf } from 'react-icons/fa'
 import * as XLSX from 'xlsx'
 import ProviderDetailModal from './ProviderDetailModal'
+import { devError } from '../utils/devLog'
 
 export default function ProvidersModule() {
   const { role, loading: authLoading } = useAuth()
@@ -33,7 +34,7 @@ export default function ProvidersModule() {
         setProviders(provSnap.docs.map((d) => ({ id: d.id, ...d.data() })))
         setInvoices(invSnap.docs.map((d) => ({ id: d.id, ...d.data() })))
       } catch (err) {
-        console.error('Error fetching providers:', err)
+        devError('Error fetching providers:', err)
         setError(err)
       } finally {
         setLoading(false)

--- a/frontend/components/SalesForm.jsx
+++ b/frontend/components/SalesForm.jsx
@@ -11,6 +11,7 @@ import {
 } from 'firebase/firestore'
 import axios from 'axios'
 import { FaSearch, FaTimes } from 'react-icons/fa'
+import { devError } from '../utils/devLog'
 
 export default function SalesForm({ onClose }) {
   const { user } = useAuth()
@@ -43,7 +44,7 @@ export default function SalesForm({ onClose }) {
         const prodsList = prodsSnap.docs.map((d) => ({ id: d.id, ...d.data() }))
         setAllProducts(prodsList)
       } catch (err) {
-        console.error('Error fetching products from Firestore:', err)
+        devError('Error fetching products from Firestore:', err)
       }
     }
     init()

--- a/frontend/components/UserForm.jsx
+++ b/frontend/components/UserForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { db } from '../firebase/config'
 import { collection, addDoc, updateDoc, doc } from 'firebase/firestore'
+import { devError } from '../utils/devLog'
 
 export default function UserForm({ onClose, userToEdit }) {
   const { role: authRole } = useAuth()
@@ -39,7 +40,7 @@ export default function UserForm({ onClose, userToEdit }) {
       alert('Usuario guardado correctamente')
       onClose()
     } catch (error) {
-      console.error('Error guardando usuario:', error)
+      devError('Error guardando usuario:', error)
       alert('Error al guardar el usuario: ' + error.message)
     }
   }

--- a/frontend/context/CartContext.js
+++ b/frontend/context/CartContext.js
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react'
+import { devError } from '../utils/devLog'
 
 const CartContext = createContext()
 
@@ -14,7 +15,7 @@ export function CartProvider({ children }) {
         setCartItems(JSON.parse(stored))
       }
     } catch (error) {
-      console.error('Error loading cart from localStorage', error)
+      devError('Error loading cart from localStorage', error)
     }
   }, [])
 
@@ -22,7 +23,7 @@ export function CartProvider({ children }) {
     try {
       localStorage.setItem('cart', JSON.stringify(cartItems))
     } catch (error) {
-      console.error('Error saving cart to localStorage', error)
+      devError('Error saving cart to localStorage', error)
     }
   }, [cartItems])
 

--- a/frontend/pages/api/advisor.js
+++ b/frontend/pages/api/advisor.js
@@ -17,6 +17,7 @@ export default async function handler(req, res) {
   const { Configuration, OpenAIApi } = await import('openai')
   const config = new Configuration({ apiKey: process.env.OPENAI_API_KEY })
   const openai = new OpenAIApi(config)
+  const { devError } = await import('../../utils/devLog')
 
   try {
     const completion = await openai.createChatCompletion({
@@ -30,7 +31,7 @@ export default async function handler(req, res) {
     const reply = completion.data.choices[0].message.content
     res.status(200).json({ response: reply })
   } catch (error) {
-    console.error('OpenAI API error:', error)
+    devError('OpenAI API error:', error)
     res.status(500).json({ error: error.message || 'OpenAI API error' })
   }
 }

--- a/frontend/pages/auth/forgot-password.jsx
+++ b/frontend/pages/auth/forgot-password.jsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { sendPasswordResetEmail } from 'firebase/auth'
 import { auth } from '../../firebase/config'
+import { devError } from '../../utils/devLog'
 
 export default function ForgotPassword() {
   const [email, setEmail] = useState('')
@@ -14,7 +15,7 @@ export default function ForgotPassword() {
       await sendPasswordResetEmail(auth, email)
       alert('Se envió un correo de restablecimiento de contraseña. Revisa tu bandeja de entrada.')
     } catch (error) {
-      console.error('Error enviando correo de restablecimiento:', error)
+      devError('Error enviando correo de restablecimiento:', error)
       alert('Error al enviar correo de restablecimiento: ' + error.message)
     }
   }

--- a/frontend/pages/auth/login.jsx
+++ b/frontend/pages/auth/login.jsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router'
 import { FcGoogle } from 'react-icons/fc'
 import { redirectByRole } from '../../utils/redirectByRole'
 import { getUserRole } from '../../utils/getUserRole'
+import { devError } from '../../utils/devLog'
 
 export default function Login() {
   const router = useRouter()
@@ -22,7 +23,7 @@ export default function Login() {
       const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
-      console.error("Error al iniciar sesión con Google:", error)
+      devError("Error al iniciar sesión con Google:", error)
     }
   }
   const handleEmailLogin = async (e) => {
@@ -34,7 +35,7 @@ export default function Login() {
       const role = await getUserRole(user.uid)
       redirectByRole(router, role)
     } catch (error) {
-      console.error('Error al iniciar sesión con correo:', error)
+      devError('Error al iniciar sesión con correo:', error)
       alert('Error al iniciar sesión: ' + error.message)
     }
   }

--- a/frontend/pages/auth/register.jsx
+++ b/frontend/pages/auth/register.jsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import { createUserWithEmailAndPassword } from 'firebase/auth'
 import { auth, db } from '../../firebase/config'
 import { doc, setDoc } from 'firebase/firestore'
+import { devError } from '../../utils/devLog'
 
 export default function Register() {
   const router = useRouter()
@@ -22,7 +23,7 @@ export default function Register() {
       alert('Registro completado. Ya puedes iniciar sesión como cliente de la tienda.')
       router.push('/auth/login')
     } catch (error) {
-      console.error('Error registrando usuario:', error)
+      devError('Error registrando usuario:', error)
       alert('Error al registrarse: ' + error.message)
     }
   }

--- a/frontend/pages/dashboard/admin/inventario/[id].jsx
+++ b/frontend/pages/dashboard/admin/inventario/[id].jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import axios from 'axios'
 import LayoutAdmin from '../../../../components/LayoutAdmin'
+import { devError } from '../../../../utils/devLog'
 
 export default function ProductDetailPage() {
   const router = useRouter()
@@ -42,7 +43,7 @@ export default function ProductDetailPage() {
             stock_minimo: data.stock_minimo || 0
           })
         })
-        .catch((err) => console.error(err))
+        .catch((err) => devError(err))
         .finally(() => setLoading(false))
     }
   }, [id])
@@ -56,7 +57,7 @@ export default function ProductDetailPage() {
           setTotalQuantity(data.totalQuantity)
           setTotalAmount(data.totalAmount)
         })
-        .catch((err) => console.error('Error fetching product sales:', err))
+        .catch((err) => devError('Error fetching product sales:', err))
     }
   }, [product])
 
@@ -73,7 +74,7 @@ export default function ProductDetailPage() {
       alert('Producto actualizado correctamente')
       router.back()
     } catch (err) {
-      console.error(err)
+      devError(err)
       alert('Error al actualizar producto')
     } finally {
       setSaving(false)
@@ -85,7 +86,7 @@ export default function ProductDetailPage() {
       await axios.post('/api/compras', { productId: id })
       alert('Solicitud de compra enviada')
     } catch (err) {
-      console.error(err)
+      devError(err)
       alert('Error al enviar solicitud de compra')
     }
   }

--- a/frontend/pages/dashboard/root/comisiones/configuracion.jsx
+++ b/frontend/pages/dashboard/root/comisiones/configuracion.jsx
@@ -3,6 +3,7 @@ import LayoutRoot from '../../../../components/LayoutRoot'
 import { useAuth } from '../../../../context/AuthContext'
 import { db } from '../../../../firebase/config'
 import { collection, getDocs, doc, updateDoc } from 'firebase/firestore'
+import { devError } from '../../../../utils/devLog'
 
 export default function CommissionConfigPage() {
   const { role } = useAuth()
@@ -38,7 +39,7 @@ export default function CommissionConfigPage() {
       )
       alert('Porcentajes de comisión guardados')
     } catch (error) {
-      console.error(error)
+      devError(error)
       alert('Error al guardar configuración: ' + error.message)
     }
   }

--- a/frontend/pages/dashboard/root/configuracion.jsx
+++ b/frontend/pages/dashboard/root/configuracion.jsx
@@ -3,6 +3,7 @@ import LayoutRoot from '../../../components/LayoutRoot'
 import { db } from '../../../firebase/config'
 import { useAuth } from '../../../context/AuthContext'
 import { doc, getDoc, setDoc, collection, getDocs, updateDoc } from 'firebase/firestore'
+import { devError } from '../../../utils/devLog'
 
 export default function ConfiguracionPage() {
   const [rate, setRate] = useState('')
@@ -65,7 +66,7 @@ export default function ConfiguracionPage() {
       )
       alert('Porcentajes de comisión guardados')
     } catch (error) {
-      console.error(error)
+      devError(error)
       alert('Error al guardar comisiones: ' + error.message)
     }
   }

--- a/frontend/pages/dashboard/root/inventario/[id].jsx
+++ b/frontend/pages/dashboard/root/inventario/[id].jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import axios from 'axios'
 import LayoutRoot from '../../../../components/LayoutRoot'
+import { devError } from '../../../../utils/devLog'
 
 export default function ProductDetailPage() {
   const router = useRouter()
@@ -42,7 +43,7 @@ export default function ProductDetailPage() {
             stock_minimo: data.stock_minimo || 0
           })
         })
-        .catch((err) => console.error(err))
+        .catch((err) => devError(err))
         .finally(() => setLoading(false))
     }
   }, [id])
@@ -56,7 +57,7 @@ export default function ProductDetailPage() {
           setTotalQuantity(data.totalQuantity)
           setTotalAmount(data.totalAmount)
         })
-        .catch((err) => console.error('Error fetching product sales:', err))
+        .catch((err) => devError('Error fetching product sales:', err))
     }
   }, [product])
 
@@ -73,7 +74,7 @@ export default function ProductDetailPage() {
       alert('Producto actualizado correctamente')
       router.back()
     } catch (err) {
-      console.error(err)
+      devError(err)
       alert('Error al actualizar producto')
     } finally {
       setSaving(false)
@@ -85,7 +86,7 @@ export default function ProductDetailPage() {
       await axios.post('/api/compras', { productId: id })
       alert('Solicitud de compra enviada')
     } catch (err) {
-      console.error(err)
+      devError(err)
       alert('Error al enviar solicitud de compra')
     }
   }

--- a/frontend/pages/tienda/[id].jsx
+++ b/frontend/pages/tienda/[id].jsx
@@ -7,6 +7,7 @@ import { useCart } from '../../context/CartContext'
 import { FiHeart } from 'react-icons/fi'
 import { db } from '../../firebase/config'
 import { doc, getDoc } from 'firebase/firestore'
+import { devError } from '../../utils/devLog'
 
 export default function ProductDetailPage() {
   const router = useRouter()
@@ -30,7 +31,7 @@ export default function ProductDetailPage() {
         const rateSnap = await getDoc(rateRef)
         setRate(rateSnap.exists() ? rateSnap.data().value : null)
       } catch (error) {
-        console.error('Error cargando detalle de producto:', error)
+        devError('Error cargando detalle de producto:', error)
       } finally {
         setLoading(false)
       }

--- a/frontend/pages/tienda/verificacion-pago.jsx
+++ b/frontend/pages/tienda/verificacion-pago.jsx
@@ -6,6 +6,7 @@ import { useCart } from '../../context/CartContext'
 import { db, storage } from '../../firebase/config'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { devError } from '../../utils/devLog'
 
 export default function PaymentVerificationPage() {
   const [pendingOrder, setPendingOrder] = useState(null)
@@ -63,7 +64,7 @@ export default function PaymentVerificationPage() {
       alert('Orden enviada correctamente. ¡Gracias!')
       router.push('/')
     } catch (error) {
-      console.error('Error al enviar orden:', error)
+      devError('Error al enviar orden:', error)
       alert('Ocurrió un error al enviar la orden')
     } finally {
       setSubmitting(false)

--- a/frontend/utils/devLog.js
+++ b/frontend/utils/devLog.js
@@ -1,0 +1,17 @@
+export const devLog = (...args) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(...args)
+  }
+}
+
+export const devWarn = (...args) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(...args)
+  }
+}
+
+export const devError = (...args) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(...args)
+  }
+}

--- a/frontend/utils/getUserRole.js
+++ b/frontend/utils/getUserRole.js
@@ -1,5 +1,6 @@
 import { db } from '../firebase/config'
 import { doc, getDoc } from 'firebase/firestore'
+import { devError } from './devLog'
 
 export async function getUserRole(userId) {
   try {
@@ -20,7 +21,7 @@ export async function getUserRole(userId) {
 
     return data?.rol ?? data?.role ?? null
   } catch (error) {
-    console.error('Error obteniendo rol de usuario:', error)
+    devError('Error obteniendo rol de usuario:', error)
     return null
   }
 }


### PR DESCRIPTION
## Summary
- add devError utility alongside devLog/devWarn
- refactor frontend to route console.error through devError

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a8ec231c832ca4260f665c75da4b